### PR TITLE
Python people try to pretend 3.3 is the first real version of 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"


### PR DESCRIPTION
Let's assume nothing exists before Python 3.3.
